### PR TITLE
[armitage-rubpcop] rubocop 0.57.2 => 0.58.1; bump to 0.4.0

### DIFF
--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name        = 'armitage-rubocop'
-  spec.version     = '0.3.0'
+  spec.version     = '0.4.0'
   spec.license     = 'MIT'
   spec.authors     = ['Rustam Ibragimov']
   spec.email       = ['iamdaiver@icloud.com']

--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.add_dependency 'rubocop', '= 0.57.2'
+  spec.add_dependency 'rubocop', '= 0.58.1'
   spec.add_dependency 'rubocop-rspec', '= 1.27.0'
 
   spec.add_development_dependency 'bundler'

--- a/armitage-rubocop/lib/general/style.yml
+++ b/armitage-rubocop/lib/general/style.yml
@@ -203,9 +203,8 @@ Style/InlineComment:
 Style/InverseMethods:
   Enabled: true
 
-# TODO: enalbe when it will be supported by rubocop
-# Style/IpAddresses:
-#   Enabled: false
+Style/IpAddresses:
+  Enabled: false
 
 Style/Lambda:
   Enabled: true


### PR DESCRIPTION
- rubocop 0.57.2 => 0.58.1
- armitage-rubocop: 0.3.0 => 0.4.0