### PR TITLE
[armitage-rubocop] update dependencies

### DIFF
--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name        = 'armitage-rubocop'
-  spec.version     = '0.8.0'
+  spec.version     = '0.9.0'
   spec.license     = 'MIT'
   spec.authors     = ['Rustam Ibragimov']
   spec.email       = ['iamdaiver@icloud.com']
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.add_dependency 'rubocop',       '= 0.59.1'
+  spec.add_dependency 'rubocop',       '= 0.59.2'
   spec.add_dependency 'rubocop-rspec', '= 1.29.1'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
- rubocop (0.59.1 => 0.59.2)