### PR TITLE
Update rubocop-rspec (1.29.1 => 1.30.0)

### DIFF
--- a/armitage-rubocop/README.md
+++ b/armitage-rubocop/README.md
@@ -37,7 +37,7 @@ inherit_gem:
 
 ```yaml
 # --- rails ---
-inheit_gem:
+inherit_gem:
   # rails-specific cops + general + rspec
   armitage-rubocop: lib/rubocop.rails.yml
 ```

--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'rubocop',       '= 0.59.2'
-  spec.add_dependency 'rubocop-rspec', '= 1.29.1'
+  spec.add_dependency 'rubocop-rspec', '= 1.30.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/armitage-rubocop/lib/rspec/rspec.yml
+++ b/armitage-rubocop/lib/rspec/rspec.yml
@@ -194,8 +194,12 @@ RSpec/SingleArgumentMessageChain:
 RSpec/SubjectStub:
   Enabled: true
 
+RSpec/UnspecifiedException:
+  Enabled: true
+
 RSpec/VerifiedDoubles:
   Enabled: false
+  IgnoreNameless: true
   IgnoreSymbolicNames: false
 
 RSpec/VoidExpect:


### PR DESCRIPTION
- rubocop-rspec 1.29.1 => 1.30.0
- new rule: `RSpec/UnspecifiedException`;
- some new minor options;