### PR TITLE
[armitage-rubocop] Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
   - language: ruby
-    rvm: 2.5.3
+    rvm: 2.6.0
     sudo: false
     before_script:
     - cd armitage-rubocop

--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name        = 'armitage-rubocop'
-  spec.version     = '0.15.0'
+  spec.version     = '0.16.0'
   spec.license     = 'MIT'
   spec.authors     = ['Rustam Ibragimov']
   spec.email       = ['iamdaiver@icloud.com']
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.add_dependency 'rubocop',       '= 0.61.1'
-  spec.add_dependency 'rubocop-rspec', '= 1.30.1'
+  spec.add_dependency 'rubocop',       '= 0.62.0'
+  spec.add_dependency 'rubocop-rspec', '= 1.31.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/armitage-rubocop/lib/general/rails.yml
+++ b/armitage-rubocop/lib/general/rails.yml
@@ -77,6 +77,9 @@ Rails/InverseOf:
 Rails/LexicallyScopedActionFilter:
   Enabled: true
 
+Rails/LinkToBlank:
+  Enabled: true
+
 Rails/NotNullColumn:
   Enabled: true
 

--- a/armitage-rubocop/lib/rspec/rspec.yml
+++ b/armitage-rubocop/lib/rspec/rspec.yml
@@ -143,6 +143,7 @@ RSpec/MultipleSubjects:
 
 RSpec/NamedSubject:
   Enabled: true
+  IgnoreSharedExamples: true
 
 RSpec/NestedGroups:
   Enabled: false


### PR DESCRIPTION
- new cop: Rails/LinkToBlank
- new options for RSpec/NamedSubject (ignore this cop in shared examples)
- new rubocop (0.62.0)
- new rubocop-rspec (1.31.0)
- run new build over the last ruby version