### PR TITLE
[armitage-rubocop] updated rubocop-rails

### DIFF
--- a/armitage-rubocop/armitage-rubocop.gemspec
+++ b/armitage-rubocop/armitage-rubocop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop',             '= 0.74.0'
   spec.add_dependency 'rubocop-performance', '= 1.4.1'
-  spec.add_dependency 'rubocop-rails',       '= 2.3.1'
+  spec.add_dependency 'rubocop-rails',       '= 2.3.2'
   spec.add_dependency 'rubocop-rspec',       '= 1.35.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
- `2.3.1` => `2.3.2`